### PR TITLE
Update seat data generation and pricing

### DIFF
--- a/packages/backend/src/data/order-dao.ts
+++ b/packages/backend/src/data/order-dao.ts
@@ -25,8 +25,8 @@ async function createOrder(
   totalPrice: number,
 ) {
   try {
-    const vipPrice = isStudent ? 70 : 80;
-    const normalPrice = isStudent ? 50 : 60;
+    const vipPrice = 45;
+    const normalPrice = isStudent ? 25 : 35;
     const lineItems = selectedSeats.map((seat) => ({
       name: `MedRevue Ticket (${seat.seatType}) - Row ${seat.rowLabel} Seat ${seat.number}`,
       price: seat.seatType === 'VIP' ? vipPrice : normalPrice,

--- a/packages/backend/src/utils/seedSeatData.ts
+++ b/packages/backend/src/utils/seedSeatData.ts
@@ -99,9 +99,9 @@ export const seedSeatData = (): SeatData => {
         seatData[row.label].push({
           number: i,
           rowLabel: row.label,
-          available: Math.random() > 0.2,
+          available: true,
           selected: false,
-          seatType: Math.random() > 0.1 ? 'Standard' : 'VIP',
+          seatType: row.label === 'H' || row.label === 'I' ? 'VIP' : 'Standard',
         });
       }
     }

--- a/packages/frontend/src/components/SeatPlanning/SeatingArrangement.ts
+++ b/packages/frontend/src/components/SeatPlanning/SeatingArrangement.ts
@@ -99,9 +99,9 @@ const generateMockSeatData = () => {
         seatData[row.label].push({
           number: i,
           rowLabel: row.label,
-          available: Math.random() > 0.2,
+          available: true,
           selected: false,
-          seatType: Math.random() > 0.1 ? 'Standard' : 'VIP',
+          seatType: row.label === 'H' || row.label === 'I' ? 'VIP' : 'Standard',
         });
       }
     }

--- a/packages/frontend/src/pages/UserDetail.tsx
+++ b/packages/frontend/src/pages/UserDetail.tsx
@@ -36,8 +36,8 @@ const UserDetail: React.FC = () => {
   );
 
   // Calculate total price with student discount
-  const vipPrice = isStudent ? 70 : 80;
-  const normalPrice = isStudent ? 50 : 60;
+  const vipPrice = 45;
+  const normalPrice = isStudent ? 25 : 35;
   const vipCount = selectedSeats.filter(
     (seat) => seat.seatType === 'VIP',
   ).length;


### PR DESCRIPTION
## Summary
- make H and I rows VIP and all seats available in mock data generators
- set VIP price to $45 and student discount to $25 for other seats

## Testing
- `npm run test:backend` *(fails: Missing STRIPE_SECRET_KEY in environment)*
- `npm run test:frontend` *(fails: test command could not run)*

------
https://chatgpt.com/codex/tasks/task_e_686258d238cc832490d68d646d4c9d88