### PR TITLE
Implement booking fee

### DIFF
--- a/packages/backend/src/data/order-dao.ts
+++ b/packages/backend/src/data/order-dao.ts
@@ -33,6 +33,16 @@ async function createOrder(
       quantity: 1,
     }));
 
+    // Calculate booking fee as 3% of the ticket subtotal
+    const bookingFee = +(totalPrice * 0.03).toFixed(2);
+    const totalPriceWithFee = +(totalPrice + bookingFee).toFixed(2);
+
+    lineItems.push({
+      name: 'Booking Fee',
+      price: bookingFee,
+      quantity: 1,
+    });
+
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
       line_items: lineItems.map(
@@ -67,7 +77,7 @@ async function createOrder(
       isStudent,
       selectedDate,
       selectedSeats,
-      totalPrice,
+      totalPrice: totalPriceWithFee,
       checkoutSessionId,
       paid: false,
     });

--- a/packages/frontend/src/pages/UserDetail.tsx
+++ b/packages/frontend/src/pages/UserDetail.tsx
@@ -44,7 +44,9 @@ const UserDetail: React.FC = () => {
   const normalCount = selectedSeats.filter(
     (seat) => seat.seatType === 'Standard',
   ).length;
-  const totalPrice = vipCount * vipPrice + normalCount * normalPrice;
+  const subTotal = vipCount * vipPrice + normalCount * normalPrice;
+  const bookingFee = +(subTotal * 0.03).toFixed(2);
+  const totalPrice = +(subTotal + bookingFee).toFixed(2);
 
   const validateForm = () => {
     const newErrors: Partial<Record<string, string>> = {};
@@ -72,7 +74,7 @@ const UserDetail: React.FC = () => {
         isStudent,
         selectedDate,
         selectedSeats,
-        totalPrice,
+        totalPrice: subTotal,
       };
       console.log('Form submitted:', formPayload);
 
@@ -254,6 +256,18 @@ const UserDetail: React.FC = () => {
                 )}
               </div>
               <div className="mt-3 text-lg">
+                <span className="font-semibold">Subtotal: </span>
+                <span className="text-[#E5CE63] font-bold">
+                  {subTotal > 0 ? `${subTotal} NZD` : '0 NZD'}
+                </span>
+              </div>
+              <div className="mt-1 text-lg">
+                <span className="font-semibold">Booking Fee (3%): </span>
+                <span className="text-[#E5CE63] font-bold">
+                  {bookingFee > 0 ? `${bookingFee} NZD` : '0 NZD'}
+                </span>
+              </div>
+              <div className="mt-1 text-lg">
                 <span className="font-semibold">Total Price: </span>
                 <span className="text-[#E5CE63] font-bold">
                   {totalPrice > 0 ? `${totalPrice} NZD` : '0 NZD'}


### PR DESCRIPTION
## Summary
- add 3% booking fee to order creation and save total including fee
- display booking fee breakdown in order summary
- send seat subtotal to backend

## Testing
- `npm run test:backend` *(fails: Missing STRIPE_SECRET_KEY)*
- `npm run test:frontend` *(fails: tests exited with code 130)*

------
https://chatgpt.com/codex/tasks/task_e_6863be24fc848324ae2caa794eaa18c6