### PR TITLE
Handle seat selection conflicts

### DIFF
--- a/packages/frontend/src/components/SeatPlanning/SeatPlanning.tsx
+++ b/packages/frontend/src/components/SeatPlanning/SeatPlanning.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   initializeSeatData,
+  setSeatUnavailable,
   setSelectedDate,
   toggleSeatSelection,
 } from '../../redux/slices/seatSelectionSlice';
@@ -95,6 +96,14 @@ export const SeatPlanning: React.FC = () => {
         );
         dispatch(toggleSeatSelection(seat));
       } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 409) {
+          dispatch(
+            setSeatUnavailable({
+              rowLabel: seat.rowLabel,
+              number: seat.number,
+            }),
+          );
+        }
         console.error('Failed to reserve seat:', error);
       }
     } else {

--- a/packages/frontend/src/redux/slices/seatSelectionSlice.ts
+++ b/packages/frontend/src/redux/slices/seatSelectionSlice.ts
@@ -36,12 +36,27 @@ const seatSelectionSlice = createSlice({
         seat.number === number ? { ...seat, selected: !seat.selected } : seat,
       );
     },
+    setSeatUnavailable: (
+      state,
+      action: PayloadAction<{ rowLabel: string; number: number }>,
+    ) => {
+      const { rowLabel, number } = action.payload;
+      state.seatData[rowLabel] = state.seatData[rowLabel].map((seat) =>
+        seat.number === number
+          ? { ...seat, available: false, selected: false }
+          : seat,
+      );
+    },
     setSelectedDate: (state, action: PayloadAction<string>) => {
       state.selectedDate = action.payload;
     },
   },
 });
 
-export const { initializeSeatData, toggleSeatSelection, setSelectedDate } =
-  seatSelectionSlice.actions;
+export const {
+  initializeSeatData,
+  toggleSeatSelection,
+  setSelectedDate,
+  setSeatUnavailable,
+} = seatSelectionSlice.actions;
 export default seatSelectionSlice.reducer;


### PR DESCRIPTION
## Summary
- update SeatPlanning to flag seat as unavailable if a 409 conflict occurs when selecting
- add setSeatUnavailable action for Redux and export it

## Testing
- `npm run format:check`
- `npm run lint:check`
- `npx vitest run` *(fails: Missing STRIPE_SECRET_KEY in environment)*

------
https://chatgpt.com/codex/tasks/task_e_686838f11e5c8324b08fd41dc36bdc57