### PR TITLE
Add return policy page

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { LoadingComponent } from './components/LoadingComponent';
 import { Menu } from './components/Menu';
 import CancelPage from './pages/CancelPage';
 import HomePage from './pages/Home';
+import ReturnPolicyPage from './pages/ReturnPolicy';
 import { SponsorPage } from './pages/SponsorPage';
 import SuccessPage from './pages/SuccessPage';
 import UserDetail from './pages/UserDetail';
@@ -101,6 +102,15 @@ const App: React.FC = () => {
             <>
               <Menu />
               <CancelPage />
+            </>
+          }
+        />
+        <Route
+          path="/return-policy"
+          element={
+            <>
+              <Menu />
+              <ReturnPolicyPage />
             </>
           }
         />

--- a/packages/frontend/src/pages/ReturnPolicy.tsx
+++ b/packages/frontend/src/pages/ReturnPolicy.tsx
@@ -1,0 +1,21 @@
+import type React from 'react';
+
+const ReturnPolicyPage: React.FC = () => {
+  return (
+    <div className="min-h-screen w-full bg-[#070507] text-[#FFFBE8] font-opensans flex flex-col items-center justify-center p-10">
+      <h1 className="text-[32px] text-[#E5CE63] font-bold mb-6">
+        Return &amp; Refund Policy
+      </h1>
+      <p className="text-lg mb-4 text-center max-w-xl">
+        Tickets purchased for Auckland Medical Revue are non-refundable except
+        where required by New Zealand consumer law. The 3% booking fee is not
+        refundable under any circumstances.
+      </p>
+      <a href="/" className="underline text-[#FFF0A2]">
+        Return Home
+      </a>
+    </div>
+  );
+};
+
+export default ReturnPolicyPage;

--- a/packages/frontend/src/pages/SuccessPage.tsx
+++ b/packages/frontend/src/pages/SuccessPage.tsx
@@ -184,7 +184,7 @@ const SuccessPage: React.FC = () => {
 
                   {/* Returns */}
                   <a
-                    href="/"
+                    href="/return-policy"
                     className={`underline text-sm ${boxText} hover:text-[#FFF0A2] block text-left px-2`}
                   >
                     Read about our return policy


### PR DESCRIPTION
## Summary
- add a ReturnPolicy page
- update SuccessPage link to the new page
- register route for ReturnPolicy page

## Testing
- `npx vitest run` *(fails: Missing STRIPE_SECRET_KEY in environment)*
- `npm run test:backend` *(fails: Missing STRIPE_SECRET_KEY in environment)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6868a904067483249bd87b204ef2b387