### PR TITLE
Adjust show info position on homepage

### DIFF
--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -241,7 +241,7 @@ const HomePage: React.FC = () => {
           </svg>
         </button> */}
 
-        <div className="absolute top-[77%] left-1/2 -translate-x-1/2 text-center lg:left-[10%] lg:-translate-x-0 lg:text-left text-[#FFFBE8] font-inter font-semibold text-3xl space-y-2 -translate-y-20 lg:translate-y-2 text-[clamp(1.5rem,3vw,2rem)]">
+        <div className="absolute top-[70%] left-1/2 -translate-x-1/2 text-center lg:left-[10%] lg:-translate-x-0 lg:text-left text-[#FFFBE8] font-inter font-semibold text-3xl space-y-2 -translate-y-20 lg:translate-y-2 text-[clamp(1.5rem,3vw,2rem)]">
           <h2>14 Aug - 16 Aug 2025</h2>
           <h2>Sky City Theatre</h2>
           <h2>Auckland</h2>


### PR DESCRIPTION
## Summary
- tweak show dates text position on the home page

## Testing
- `npm run format:check`
- `npm run lint:check`
- `npm exec vitest --workspace packages/frontend -- run`


------
https://chatgpt.com/codex/tasks/task_e_6869131f481c8324802fae3b954b2f3d