### PR TITLE
Adjust seat lock timings

### DIFF
--- a/packages/backend/src/routes/api/api-orders.ts
+++ b/packages/backend/src/routes/api/api-orders.ts
@@ -123,6 +123,14 @@ router.post(
         return;
       }
 
+      // Extend the seat lock time by an additional 30 minutes
+      for (const seat of selectedSeats) {
+        const lockKey = `seatlock:${selectedDate}:${seat.rowLabel}-${seat.number}`;
+        const ttl = await redisClient.ttl(lockKey);
+        const newTtl = ttl > 0 ? ttl + 30 * 60 : 30 * 60;
+        await redisClient.expire(lockKey, newTtl);
+      }
+
       const order = await createOrder(
         firstName,
         lastName,

--- a/packages/backend/src/routes/api/api-seats.ts
+++ b/packages/backend/src/routes/api/api-seats.ts
@@ -129,7 +129,8 @@ router.post('/select', async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    await redisClient.set(lockKey, req.sessionID, { EX: 30 * 60 });
+    // Reserve the seat for 10 minutes
+    await redisClient.set(lockKey, req.sessionID, { EX: 10 * 60 });
 
     res.status(200).json({ message: 'Seat reserved' });
   } catch (error) {


### PR DESCRIPTION
## Summary
- reduce seat selection lock to 10 minutes
- extend seat locks by 30 minutes when an order is created

## Testing
- `npm run lint`
- `npm run test:backend` *(fails: Missing STRIPE_SECRET_KEY)*
- `npm run test:frontend` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_686ae01ab1108324b822415ebd1d0e68