### PR TITLE
Implement student count option in bookings

### DIFF
--- a/packages/backend/src/data/order-dao.ts
+++ b/packages/backend/src/data/order-dao.ts
@@ -21,6 +21,7 @@ async function createOrder(
   email: string,
   phone: string,
   isStudent: boolean,
+  studentCount: number,
   selectedDate: string,
   selectedSeats: {
     rowLabel: string;
@@ -31,12 +32,28 @@ async function createOrder(
 ) {
   try {
     const vipPrice = 45;
-    const normalPrice = isStudent ? 25 : 35;
-    const lineItems = selectedSeats.map((seat) => ({
-      name: `MedRevue Ticket (${seat.seatType}) - Row ${seat.rowLabel} Seat ${seat.number}`,
-      price: seat.seatType === 'VIP' ? vipPrice : normalPrice,
-      quantity: 1,
-    }));
+    const standardStudentPrice = 25;
+    const standardPrice = 35;
+    let remainingStudent = Math.min(
+      studentCount,
+      selectedSeats.filter((s) => s.seatType === 'Standard').length,
+    );
+    const lineItems = selectedSeats.map((seat) => {
+      let price = vipPrice;
+      if (seat.seatType === 'Standard') {
+        if (remainingStudent > 0) {
+          price = standardStudentPrice;
+          remainingStudent -= 1;
+        } else {
+          price = standardPrice;
+        }
+      }
+      return {
+        name: `MedRevue Ticket (${seat.seatType}) - Row ${seat.rowLabel} Seat ${seat.number}`,
+        price,
+        quantity: 1,
+      };
+    });
 
     // Calculate booking fee as 3% of the ticket subtotal
     const bookingFee = +(totalPrice * 0.03).toFixed(2);
@@ -80,6 +97,7 @@ async function createOrder(
       email,
       phone,
       isStudent,
+      studentCount,
       selectedDate,
       selectedSeats,
       totalPrice: totalPriceWithFee,
@@ -115,6 +133,7 @@ async function updateOrder(order: IOrder): Promise<boolean> {
         email: order.email,
         phone: order.phone,
         isStudent: order.isStudent,
+        studentCount: order.studentCount,
         selectedDate: order.selectedDate,
         selectedSeats: order.selectedSeats,
         totalPrice: order.totalPrice,

--- a/packages/backend/src/models/order.ts
+++ b/packages/backend/src/models/order.ts
@@ -10,6 +10,7 @@ const orderSchema: Schema<IOrder> = new Schema(
     email: { type: String, required: true },
     phone: { type: String, required: true },
     isStudent: { type: Boolean, required: true },
+    studentCount: { type: Number, required: true },
     selectedDate: { type: String, required: true },
     selectedSeats: [
       {

--- a/packages/backend/src/routes/api/api-orders.ts
+++ b/packages/backend/src/routes/api/api-orders.ts
@@ -39,6 +39,7 @@ interface CreateOrderRequest extends Request {
     email: string;
     phone: string;
     isStudent: boolean;
+    studentCount: number;
     selectedDate: string;
     selectedSeats: {
       rowLabel: string;
@@ -63,6 +64,7 @@ router.post(
         selectedDate,
         selectedSeats,
         totalPrice,
+        studentCount,
       } = req.body;
 
       // Validate required fields
@@ -84,6 +86,10 @@ router.post(
       }
       if (typeof isStudent !== 'boolean') {
         res.status(400).json({ error: 'Missing isStudent' });
+        return;
+      }
+      if (typeof studentCount !== 'number') {
+        res.status(400).json({ error: 'Missing student count' });
         return;
       }
       if (!selectedDate) {
@@ -134,6 +140,7 @@ router.post(
         email,
         phone,
         isStudent,
+        studentCount,
         selectedDate,
         selectedSeats,
         totalPrice,

--- a/packages/types/src/orders.d.ts
+++ b/packages/types/src/orders.d.ts
@@ -4,6 +4,7 @@ export interface OrderType {
   email: string;
   phone: string;
   isStudent: boolean;
+  studentCount: number;
   selectedDate: string;
   selectedSeats: {
     rowLabel: string;


### PR DESCRIPTION
## Summary
- add `studentCount` to order types and database model
- handle student count in API validation and creation logic
- compute student/student price split in order DAO
- allow users to specify number of students during checkout

## Testing
- `npm run test:frontend` *(fails: watch mode ended manually)*
- `npm run test:backend` *(fails: Missing STRIPE_SECRET_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_686b2f7eb9cc8324852482733de6d5be