### PR TITLE
Implement scheduled status checks

### DIFF
--- a/packages/backend/src/routes/api/api-orders.ts
+++ b/packages/backend/src/routes/api/api-orders.ts
@@ -14,6 +14,7 @@ import { markSeatsUnavailable } from '../../data/seat-dao';
 import { verifyInternalRequest } from '../../middleware/verify-internal-request';
 import redisClient from '../../redis/redisClient';
 import { refreshSeatCache } from '../../redis/seatCache';
+import { scheduleStatusChecks } from '../../utils/scheduleStatusChecks';
 import { verifySeats } from '../../utils/verifySeats';
 
 declare module 'express-session' {
@@ -156,6 +157,8 @@ router.post(
       req.session.orderId = (
         order._id as string | { toString(): string }
       ).toString();
+
+      scheduleStatusChecks(req.session.orderId);
 
       res.status(201).json({
         sessionId: order.checkoutSessionId,

--- a/packages/backend/src/utils/scheduleStatusChecks.ts
+++ b/packages/backend/src/utils/scheduleStatusChecks.ts
@@ -1,0 +1,16 @@
+export function scheduleStatusChecks(orderId: string): void {
+  const baseUrl =
+    process.env.API_BASE_URL ?? `http://localhost:${process.env.PORT ?? 3000}`;
+
+  const checkStatus = async () => {
+    try {
+      await fetch(`${baseUrl}/api/v1/orders/order-status/${orderId}`);
+    } catch (err) {
+      console.error(`Status check failed for order ${orderId}:`, err);
+    }
+  };
+
+  for (const minutes of [10, 20, 30, 40, 50]) {
+    setTimeout(checkStatus, minutes * 60 * 1000);
+  }
+}


### PR DESCRIPTION
## Summary
- add `scheduleStatusChecks` utility to poll order payment status
- trigger the scheduler when a new order is created

## Testing
- `npm run lint`
- `STRIPE_SECRET_KEY=dummy npm run test:backend` *(fails: Redis connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686f870d5c4883248c7673bb6530005e